### PR TITLE
fix: User 엔티티 변경에 맞춰 프로필 이미지 불러오기 로직 변경

### DIFF
--- a/momentia-api/src/main/java/org/ject/momentia/api/artwork/converter/ArtworkCommentConverter.java
+++ b/momentia-api/src/main/java/org/ject/momentia/api/artwork/converter/ArtworkCommentConverter.java
@@ -6,7 +6,7 @@ import org.ject.momentia.common.domain.user.User;
 
 public class ArtworkCommentConverter {
 
-	public static ArtworkCommentModel ArtworkCommentToArtworkCommentModel(ArtworkComment comment, String imageUrl,
+	public static ArtworkCommentModel ArtworkCommentToArtworkCommentModel(ArtworkComment comment,
 		User user) {
 		boolean isMine = false;
 		if (user != null)
@@ -16,7 +16,8 @@ public class ArtworkCommentConverter {
 			.userId(comment.getUser().getId())
 			.content(comment.getContent())
 			.isMine(isMine)
-			.profileImage(imageUrl)
+			.profileImage(
+				comment.getUser().getProfileImage() == null ? null : comment.getUser().getProfileImage().getImageSrc())
 			.createdTime(comment.getCreatedAt())
 			.nickname(comment.getUser().getNickname())
 			.build();

--- a/momentia-api/src/main/java/org/ject/momentia/api/artwork/converter/ArtworkPostConverter.java
+++ b/momentia-api/src/main/java/org/ject/momentia/api/artwork/converter/ArtworkPostConverter.java
@@ -40,7 +40,7 @@ public class ArtworkPostConverter {
 	}
 
 	public static ArtworkPostResponse toArtworkPostResponse(ArtworkPost artworkPost, boolean isMine, boolean isLiked,
-		String imageUrl, Boolean isFollow, String profileImage) {
+		String imageUrl, Boolean isFollow) {
 		return ArtworkPostResponse.builder()
 			.postId(artworkPost.getId())
 			.postImage(imageUrl)
@@ -58,7 +58,8 @@ public class ArtworkPostConverter {
 			.nickname(artworkPost.getUser().getNickname())
 			.introduction(artworkPost.getUser().getIntroduction())
 			.isFollow(isFollow)
-			.profileImage(profileImage)
+			.profileImage(artworkPost.getUser().getProfileImage() == null ? null :
+				artworkPost.getUser().getProfileImage().getImageSrc())
 
 			.isMine(isMine)
 			.isLiked(isLiked)
@@ -89,11 +90,11 @@ public class ArtworkPostConverter {
 			.build();
 	}
 
-	public static FollowingUserModel toFollowingUserModel(User user, String imageUrl) {
+	public static FollowingUserModel toFollowingUserModel(User user) {
 		return FollowingUserModel.builder()
 			.userId(user.getId())
 			.nickname(user.getNickname())
-			.userImage(imageUrl)
+			.userImage(user.getProfileImage() == null ? null : user.getProfileImage().getImageSrc())
 			.isFollow(true) // 팔로잉한 유저에서 가져온 데이터 이므로 무조건 true로 반환
 			.userField(user.getField() == null ? null : user.getField().getKoreanName())
 			.posts(new ArrayList<>())

--- a/momentia-api/src/main/java/org/ject/momentia/api/artwork/service/ArtworkCommentService.java
+++ b/momentia-api/src/main/java/org/ject/momentia/api/artwork/service/ArtworkCommentService.java
@@ -1,83 +1,82 @@
 package org.ject.momentia.api.artwork.service;
 
-import jakarta.transaction.Transactional;
-import lombok.AllArgsConstructor;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import org.ject.momentia.api.artwork.converter.ArtworkCommentConverter;
 import org.ject.momentia.api.artwork.converter.ArtworkPostConverter;
-import org.ject.momentia.api.artwork.model.ArtworkCommentRequest;
 import org.ject.momentia.api.artwork.model.ArtworkCommentIdResponse;
 import org.ject.momentia.api.artwork.model.ArtworkCommentListResponse;
 import org.ject.momentia.api.artwork.model.ArtworkCommentModel;
+import org.ject.momentia.api.artwork.model.ArtworkCommentRequest;
 import org.ject.momentia.api.artwork.repository.ArtworkCommentRepository;
 import org.ject.momentia.api.artwork.service.module.ArtworkPostModuleService;
 import org.ject.momentia.api.exception.ErrorCd;
 import org.ject.momentia.api.image.service.ImageService;
 import org.ject.momentia.common.domain.artwork.ArtworkComment;
 import org.ject.momentia.common.domain.artwork.ArtworkPost;
-import org.ject.momentia.common.domain.image.type.ImageTargetType;
 import org.ject.momentia.common.domain.user.User;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
 
 @Service
 @AllArgsConstructor
 public class ArtworkCommentService {
 
-    private final ArtworkCommentRepository artworkCommentRepository;
+	private final ArtworkCommentRepository artworkCommentRepository;
 
-    private final ImageService imageService;
-    private final ArtworkPostModuleService artworkService;
+	private final ImageService imageService;
+	private final ArtworkPostModuleService artworkService;
 
-    @Transactional
-    public ArtworkCommentIdResponse createComment(User user, Long postId, ArtworkCommentRequest artworkCommentCreateRequest) {
-        ArtworkPost post = artworkService.findPostByIdElseThrowError(postId);
-        ArtworkComment comment = ArtworkPostConverter.from(artworkCommentCreateRequest, post, user);
-        comment = artworkCommentRepository.save(comment);
+	@Transactional
+	public ArtworkCommentIdResponse createComment(User user, Long postId,
+		ArtworkCommentRequest artworkCommentCreateRequest) {
+		ArtworkPost post = artworkService.findPostByIdElseThrowError(postId);
+		ArtworkComment comment = ArtworkPostConverter.from(artworkCommentCreateRequest, post, user);
+		comment = artworkCommentRepository.save(comment);
 
-        post.increaseCommentCount();
+		post.increaseCommentCount();
 
-        return new ArtworkCommentIdResponse(comment.getId());
-    }
+		return new ArtworkCommentIdResponse(comment.getId());
+	}
 
-    @Transactional
-    public void deleteComment(User user, Long commentId) {
-        ArtworkComment comment = artworkCommentRepository.findById(commentId).orElseThrow(ErrorCd.ARTWORK_COMMENT_NOT_FOUND::serviceException);
-        if (user == null || !comment.getUser().getId().equals(user.getId()))
-            throw ErrorCd.NO_PERMISSION.serviceException();
-        artworkCommentRepository.delete(comment);
+	@Transactional
+	public void deleteComment(User user, Long commentId) {
+		ArtworkComment comment = artworkCommentRepository.findById(commentId)
+			.orElseThrow(ErrorCd.ARTWORK_COMMENT_NOT_FOUND::serviceException);
+		if (user == null || !comment.getUser().getId().equals(user.getId()))
+			throw ErrorCd.NO_PERMISSION.serviceException();
+		artworkCommentRepository.delete(comment);
 
-        comment.getPost().decreaseCommentCount();
-    }
+		comment.getPost().decreaseCommentCount();
+	}
 
-    @Transactional
-    public ArtworkCommentListResponse getCommentList(User user, Long postId, Long skip, Long size) {
-        artworkService.findPostByIdElseThrowError(postId);
-        List<ArtworkComment> commentList =
-                artworkCommentRepository.findByArtworkIdOrderByCreatedAtDescForInfiniteScrolling(postId, skip, size);
-        List<ArtworkCommentModel> comments =
-                commentList.stream()
-                        .map(comment -> {
-                            // 프로필 이미지
-                            String imageUrl = null;
-                            if(comment.getUser().getProfileImage()!=null) imageUrl = imageService.getImageUrl(ImageTargetType.PROFILE,user.getId());
-                            return ArtworkCommentConverter.ArtworkCommentToArtworkCommentModel(
-                                    comment,
-                                    imageUrl,
-                                    user
-                            );
-                        }).collect(Collectors.toList());
-        return new ArtworkCommentListResponse(comments);
-    }
+	@Transactional
+	public ArtworkCommentListResponse getCommentList(User user, Long postId, Long skip, Long size) {
+		artworkService.findPostByIdElseThrowError(postId);
+		List<ArtworkComment> commentList =
+			artworkCommentRepository.findByArtworkIdOrderByCreatedAtDescForInfiniteScrolling(postId, skip, size);
+		List<ArtworkCommentModel> comments =
+			commentList.stream()
+				.map(comment -> {
+					return ArtworkCommentConverter.ArtworkCommentToArtworkCommentModel(
+						comment,
+						user
+					);
+				}).collect(Collectors.toList());
+		return new ArtworkCommentListResponse(comments);
+	}
 
-    @Transactional
-    public void updateComment(User user, Long commentId, ArtworkCommentRequest artworkCommentUpdateRequest) {
-        ArtworkComment comment = artworkCommentRepository.findById(commentId).orElseThrow(ErrorCd.ARTWORK_COMMENT_NOT_FOUND::serviceException);
-        if(user == null || !Objects.equals(comment.getUser().getId(), user.getId())) ErrorCd.NO_PERMISSION.serviceException();
-        comment.update(artworkCommentUpdateRequest.content());
-    }
-
+	@Transactional
+	public void updateComment(User user, Long commentId, ArtworkCommentRequest artworkCommentUpdateRequest) {
+		ArtworkComment comment = artworkCommentRepository.findById(commentId)
+			.orElseThrow(ErrorCd.ARTWORK_COMMENT_NOT_FOUND::serviceException);
+		if (user == null || !Objects.equals(comment.getUser().getId(), user.getId()))
+			ErrorCd.NO_PERMISSION.serviceException();
+		comment.update(artworkCommentUpdateRequest.content());
+	}
 
 }

--- a/momentia-api/src/main/java/org/ject/momentia/api/artwork/service/ArtworkPostService.java
+++ b/momentia-api/src/main/java/org/ject/momentia/api/artwork/service/ArtworkPostService.java
@@ -83,8 +83,7 @@ public class ArtworkPostService {
 		String profileImage = artworkPost.getUser().getProfileImage() != null ?
 			imageService.getImageUrl(ImageTargetType.PROFILE, artworkPost.getUser().getId()) : null;
 
-		return ArtworkPostConverter.toArtworkPostResponse(artworkPost, isMine, isLiked, postImage, isFollow,
-			profileImage);
+		return ArtworkPostConverter.toArtworkPostResponse(artworkPost, isMine, isLiked, postImage, isFollow);
 	}
 
 	@Transactional
@@ -164,7 +163,7 @@ public class ArtworkPostService {
 			String imageUrl = null;
 			if (u.getProfileImage() != null)
 				imageUrl = imageService.getImageUrl(ImageTargetType.PROFILE, u.getId());
-			return ArtworkPostConverter.toFollowingUserModel(u, imageUrl);
+			return ArtworkPostConverter.toFollowingUserModel(u);
 		}).collect(Collectors.toList());
 
 		Iterator<FollowingUserModel> iterator = userModelList.iterator();

--- a/momentia-api/src/main/java/org/ject/momentia/api/monthly/converter/MonthlyUserConverter.java
+++ b/momentia-api/src/main/java/org/ject/momentia/api/monthly/converter/MonthlyUserConverter.java
@@ -4,7 +4,7 @@ import org.ject.momentia.api.monthly.model.UserListModel;
 import org.ject.momentia.common.domain.user.User;
 
 public class MonthlyUserConverter {
-	public static UserListModel toUserListModel(User user, String profileImage, String artworkImage, Boolean isFollow) {
+	public static UserListModel toUserListModel(User user, String artworkImage, Boolean isFollow) {
 		return UserListModel.builder()
 			.userId(user.getId())
 			.artworkImage(artworkImage)
@@ -12,7 +12,7 @@ public class MonthlyUserConverter {
 			.userField(user.getField() == null ? null : user.getField().getKoreanName())
 			.introduction(user.getIntroduction())
 			.isFollow(isFollow)
-			.profileImage(profileImage)
+			.profileImage(user.getProfileImage() == null ? null : user.getProfileImage().getImageSrc())
 			.build();
 	}
 }

--- a/momentia-api/src/main/java/org/ject/momentia/api/monthly/service/MonthlyService.java
+++ b/momentia-api/src/main/java/org/ject/momentia/api/monthly/service/MonthlyService.java
@@ -1,7 +1,9 @@
 package org.ject.momentia.api.monthly.service;
 
-import jakarta.transaction.Transactional;
-import lombok.AllArgsConstructor;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.ject.momentia.api.artwork.converter.ArtworkPostConverter;
 import org.ject.momentia.api.artwork.model.ArtworkPostModel;
 import org.ject.momentia.api.artwork.service.module.ArtworkLikeModuleService;
@@ -22,79 +24,79 @@ import org.ject.momentia.common.domain.monthly.MonthlyArtwork;
 import org.ject.momentia.common.domain.monthly.MonthlyUser;
 import org.ject.momentia.common.domain.user.User;
 import org.springframework.stereotype.Service;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
 
 @Service
 @AllArgsConstructor
 public class MonthlyService {
 
-    private final MonthlyPostRepository monthlyPostRepository;
-    private final MonthlyUserRepository monthlyUserRepository;
-    private final UserRepository userRepository;
+	private final MonthlyPostRepository monthlyPostRepository;
+	private final MonthlyUserRepository monthlyUserRepository;
+	private final UserRepository userRepository;
 
-    private final ArtworkPostModuleService artworkService;
-    private final ArtworkLikeModuleService artworkLikeService;
-    private final FollowModuleService followService;
+	private final ArtworkPostModuleService artworkService;
+	private final ArtworkLikeModuleService artworkLikeService;
+	private final FollowModuleService followService;
 
-    private final ImageService imageService;
+	private final ImageService imageService;
 
-    @Transactional
-    public MonthlyPostsResponse getMonthlyPosts(User user) {
-        /// 일단 고정으로 박아둠 -> 추후 수정
-        List<MonthlyArtwork> artworkList = monthlyPostRepository.findAllByMonthAndYearOrderByRankAsc(12, 2024);
+	@Transactional
+	public MonthlyPostsResponse getMonthlyPosts(User user) {
+		/// 일단 고정으로 박아둠 -> 추후 수정
+		List<MonthlyArtwork> artworkList = monthlyPostRepository.findAllByMonthAndYearOrderByRankAsc(12, 2024);
 
-        List<Long> ids = artworkList.stream().map((a) -> a.getPost().getId()).toList();
+		List<Long> ids = artworkList.stream().map((a) -> a.getPost().getId()).toList();
 
-        // id들 보내면, post List 반환 하는 service 함수 , public 작품만 반환
-        List<ArtworkPost> posts = artworkService.getPostsByIdsAndStatus(ids, ArtworkPostStatus.PUBLIC);
+		// id들 보내면, post List 반환 하는 service 함수 , public 작품만 반환
+		List<ArtworkPost> posts = artworkService.getPostsByIdsAndStatus(ids, ArtworkPostStatus.PUBLIC);
 
-        // id 값으로 post 찾을 수 있도록 map 생성  ( artworkList 순서 유지를 위함 )
-        Map<Long, ArtworkPost> idToPostMap = posts.stream().filter(post -> ids.contains(post.getId()))
-                .collect(Collectors.toMap(ArtworkPost::getId, post -> post
-                ));
+		// id 값으로 post 찾을 수 있도록 map 생성  ( artworkList 순서 유지를 위함 )
+		Map<Long, ArtworkPost> idToPostMap = posts.stream().filter(post -> ids.contains(post.getId()))
+			.collect(Collectors.toMap(ArtworkPost::getId, post -> post
+			));
 
-        List<ArtworkPostModel> postModelList = artworkList.stream()
-                .map((p) -> {
-                            ArtworkPost post = idToPostMap.get(p.getPost().getId());
-                            Boolean isLiked = user != null && artworkLikeService.isLiked(user, post);
-                            String imageUrl = imageService.getImageUrl(ImageTargetType.ARTWORK,post.getId());
-                            return ArtworkPostConverter.toArtworkPostModel(post, isLiked, imageUrl);
-                        }
-                )
-                .toList();
+		List<ArtworkPostModel> postModelList = artworkList.stream()
+			.map((p) -> {
+					ArtworkPost post = idToPostMap.get(p.getPost().getId());
+					Boolean isLiked = user != null && artworkLikeService.isLiked(user, post);
+					String imageUrl = imageService.getImageUrl(ImageTargetType.ARTWORK, post.getId());
+					return ArtworkPostConverter.toArtworkPostModel(post, isLiked, imageUrl);
+				}
+			)
+			.toList();
 
-        return new MonthlyPostsResponse(postModelList);
-    }
+		return new MonthlyPostsResponse(postModelList);
+	}
 
-    @Transactional
-    public MonthlyUsersResponse getMonthlyUsers(User user) {
-        /// 일단 고정으로 박아둠 -> 추후 수정
-        List<MonthlyUser> monthlyUsers = monthlyUserRepository.findAllByMonthAndYearOrderByRankAsc(12, 2024);
+	@Transactional
+	public MonthlyUsersResponse getMonthlyUsers(User user) {
+		/// 일단 고정으로 박아둠 -> 추후 수정
+		List<MonthlyUser> monthlyUsers = monthlyUserRepository.findAllByMonthAndYearOrderByRankAsc(12, 2024);
 
-        List<Long> ids = monthlyUsers.stream()
-                .map((a) -> a.getUser().getId())
-                .toList();
+		List<Long> ids = monthlyUsers.stream()
+			.map((a) -> a.getUser().getId())
+			.toList();
 
-        Map<Long, User> userMap = userRepository.findAllByIdIn(ids).stream()
-                .collect(Collectors.toMap(User::getId, User -> User));
+		Map<Long, User> userMap = userRepository.findAllByIdIn(ids).stream()
+			.collect(Collectors.toMap(User::getId, User -> User));
 
-        // monthlyUsers의 순서대로 UserListModel을 생성합니다.
-        List<UserListModel> userListModels = monthlyUsers.stream().map((monthlyUser) -> {
-            User u = userMap.get(monthlyUser.getUser().getId());
+		// monthlyUsers의 순서대로 UserListModel을 생성합니다.
+		List<UserListModel> userListModels = monthlyUsers.stream().map((monthlyUser) -> {
+			User u = userMap.get(monthlyUser.getUser().getId());
 
-            // 대표작
-            ArtworkPost artwork = artworkService.getPopularArtworkByUser(u);
-            String postImage = imageService.getImageUrl(ImageTargetType.ARTWORK,artwork.getId());
-            String profileImage = u.getProfileImage()!=null ? imageService.getImageUrl(ImageTargetType.PROFILE,u.getId()) : null;
+			// 대표작
+			ArtworkPost artwork = artworkService.getPopularArtworkByUser(u);
+			String postImage =
+				artwork == null ? null : imageService.getImageUrl(ImageTargetType.ARTWORK, artwork.getId());
 
-            // 좋아요 여부
-            Boolean isFollow = followService.isFollowing(user, u);
+			// 좋아요 여부
+			Boolean isFollow = followService.isFollowing(user, u);
 
-            return MonthlyUserConverter.toUserListModel(u, profileImage, postImage, isFollow);
-        }).toList();
-        return new MonthlyUsersResponse(userListModels);
-    }
+			return MonthlyUserConverter.toUserListModel(u, postImage, isFollow);
+		}).toList();
+		return new MonthlyUsersResponse(userListModels);
+	}
 
 }


### PR DESCRIPTION
- User 엔티티 변경에 맞춰 프로필 이미지 불러오기 로직 변경 ( 하단 API에서 사용된 converter 메서드 변경 )
        - 작품 상세 보기
        - 월간 작가
        - 팔로잉 유저의 작품 리스트
        - 댓글 리스트 