### PR TITLE
fix: 조회수 업데이트 시, 레디스에서 작품 정보 삭제

### DIFF
--- a/momentia-api/src/main/java/org/ject/momentia/api/artwork/schedule/service/ArtworkScheduleService.java
+++ b/momentia-api/src/main/java/org/ject/momentia/api/artwork/schedule/service/ArtworkScheduleService.java
@@ -77,6 +77,7 @@ public class ArtworkScheduleService {
 				}
 			});
 			artworkViewCacheRepository.deleteById(id);
+			artworkPostCacheRepository.deleteById(id);
 		}
 	}
 


### PR DESCRIPTION
- 스케줄링으로 조회수 업데이트 시, 레디스에서 작품 정보 삭제